### PR TITLE
Monies should use Decimal types instead of Double

### DIFF
--- a/XMerchant/PayPal/PayPalManager.cs
+++ b/XMerchant/PayPal/PayPalManager.cs
@@ -60,9 +60,9 @@ namespace XMerchant.PayPal
 			trans.SubscriptionChangeEffectiveDate = DateTime.TryParse(form[PayPalResponseVariables.SubscriptionInformation.SubscriptionChangeEffectiveDate], out dt) ? (DateTime?)dt : null;
 			trans.SubscriptionID                  = form[PayPalResponseVariables.SubscriptionInformation.SubscriptionID];
 
-			double d;
-			trans.GrossAmount    = double.TryParse(form[PayPalResponseVariables.PaymentInformation.GrossAmount], out d) ? (double?)d : null;
-			trans.TransactionFee = double.TryParse(form[PayPalResponseVariables.PaymentInformation.TransactionFee], out d) ? (double?)d : null;
+			decimal d;
+			trans.GrossAmount    = decimal.TryParse(form[PayPalResponseVariables.PaymentInformation.GrossAmount], out d) ? (decimal?)d : null;
+			trans.TransactionFee = decimal.TryParse(form[PayPalResponseVariables.PaymentInformation.TransactionFee], out d) ? (decimal?)d : null;
 			trans.PaymentStatus  = form[PayPalResponseVariables.PaymentInformation.PaymentStatus] == null ? null : (PayPalPaymentStatus?)GetPaymentStatus(form[PayPalResponseVariables.PaymentInformation.PaymentStatus]);
 			trans.ReasonCode     = form[PayPalResponseVariables.PaymentInformation.ReasonCode] == null ? null : (PayPalReasonCode?)GetReasonCode(form[PayPalResponseVariables.PaymentInformation.ReasonCode]);
 
@@ -81,7 +81,7 @@ namespace XMerchant.PayPal
 			var period = GetPeriod(form[periodVar]);
 			return new PayPalTransaction.Period
 			{
-				Amount = double.Parse(form[amountVar]),
+				Amount = decimal.Parse(form[amountVar]),
 				Length = period.Item1,
 				Unit = period.Item2
 			};

--- a/XMerchant/PayPal/PayPalTransaction.cs
+++ b/XMerchant/PayPal/PayPalTransaction.cs
@@ -167,7 +167,7 @@ namespace XMerchant.PayPal
 			/// <summary>
 			/// Charged amount for the period. 0 = free
 			/// </summary>
-			public double Amount { get; set; }
+			public decimal Amount { get; set; }
 		}
 
 		/// <summary>
@@ -222,8 +222,8 @@ namespace XMerchant.PayPal
 		#endregion
 
 		#region Payment Information Variables
-		public double? TransactionFee { get; set; }
-		public double? GrossAmount { get; set; }
+		public decimal? TransactionFee { get; set; }
+		public decimal? GrossAmount { get; set; }
 		public PayPalPaymentStatus? PaymentStatus { get; set; }
 		public PayPalReasonCode? ReasonCode { get; set; }
 		#endregion

--- a/XMerchant/PayPal/PaypalBuyNowRequest.cs
+++ b/XMerchant/PayPal/PaypalBuyNowRequest.cs
@@ -22,17 +22,17 @@ namespace XMerchant.PayPal
 		/// <summary>
 		/// The price or amount of the product, service, or contribution, not including shipping, handling, or tax. If omitted from Buy Now or Donate buttons, payers enter their own amount at the time of payment.
 		/// </summary>
-		public double? Amount { get; set; }
+		public decimal? Amount { get; set; }
 
 		/// <summary>
 		/// Discount amount associated with an item. It must be less than the selling price of the item. If you specify discount_amount and discount_amount2 is not defined, then this flat amount is applied regardless of the quantity of items purchased. Valid only for Buy Now and Add to Cart buttons.
 		/// </summary>
-		public double? DiscountAmount { get; set; }
+		public decimal? DiscountAmount { get; set; }
 
 		/// <summary>
 		/// Discount rate (percentage) associated with an item. It must be set to a value less than 100. If you do not set discount_rate2, the value in discount_rate applies only to the first item regardless of the quantity of items purchased. Valid only for Buy Now and Add to Cart buttons.
 		/// </summary>
-		public double? DiscountRate { get; set; }
+		public decimal? DiscountRate { get; set; }
 
 		/// <summary>
 		/// Weight of items. If profile-based shipping rates are configured with a basis of weight, the sum of weight values is used to calculate the shipping charges for the transaction.
@@ -57,17 +57,17 @@ namespace XMerchant.PayPal
 		/// <summary>
 		/// The cost of shipping this item. If you specify shipping and shipping2 is not defined, this flat amount is charged regardless of the quantity of items purchased. This use of the shipping variable is valid only for Buy Now and Add to Cart buttons. Default – If profile-based shipping rates are configured, buyers are charged an amount according to the shipping methods they choose.
 		/// </summary>
-		public double? ShippingAmount { get; set; }
+		public decimal? ShippingAmount { get; set; }
 
 		/// <summary>
 		/// Transaction-based tax override variable. Set this to a flat tax amount to apply to the transaction regardless of the buyer’s location. This value overrides any tax settings set in your account profile. Valid only for Buy Now and Add to Cart buttons. Default – Profile tax settings, if any, apply.
 		/// </summary>
-		public double? TaxAmount { get; set; }
+		public decimal? TaxAmount { get; set; }
 
 		/// <summary>
 		/// Transaction-based tax override variable. Set this to a percentage that will be applied to amount multiplied the quantity selected during checkout. This value overrides any tax settings set in your account profile. Allowable values are numbers 0.001 through 100. Valid only for Buy Now and Add to Cart buttons. Default – Profile tax settings, if any, apply.
 		/// </summary>
-		public double? TaxRate { get; set; }
+		public decimal? TaxRate { get; set; }
 
 		/// <summary>
 		/// Passed back when the payment is made. Max 255 characters.

--- a/XMerchant/PayPal/PaypalSubscriptionRequest.cs
+++ b/XMerchant/PayPal/PaypalSubscriptionRequest.cs
@@ -68,7 +68,7 @@ namespace XMerchant.PayPal
 			/// <summary>
 			/// Cost of the period. Set to 0 to make it free.
 			/// </summary>
-			public double Price { get; set; }
+			public decimal Price { get; set; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi there,

Slight change to your Paypal stuff.

Amounts and Monies should use Decimal types instead of Double storage.

Thanks,
cowboy

More information here:
http://stackoverflow.com/questions/316727/is-a-double-really-unsuitable-for-money
